### PR TITLE
Added token provider for Symfony DI Container parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
     - SYMFONY_VERSION=2.5.*
 
 matrix:
-  allow_failures:
-    - php: hhvm
   include:
     - php: 5.5
       env: SYMFONY_VERSION=2.3.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+dev-master
+----------
+
+**2014-01-29**: Added SymfonyContainerParameterTokenProvider for retrieving
+                path elements from the DI container
+
 1.0
 ---
 

--- a/Tests/Unit/TokenProvider/SymfonyContainerParameterProviderTest.php
+++ b/Tests/Unit/TokenProvider/SymfonyContainerParameterProviderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\RoutingAuto\Tests\Unit\TokenProvider;
+
+use Symfony\Cmf\Component\RoutingAuto\Tests\Unit\BaseTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Cmf\Component\RoutingAuto\TokenProvider\SymfonyContainerParameterProvider;
+
+class SymfonyContainerParameterProviderTest extends BaseTestCase
+{
+    private $uriContext;
+    private $container;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->uriContext = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\UriContext');
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->provider = new SymfonyContainerParameterProvider($this->container->reveal());
+    }
+
+    public function provideParameterValue()
+    {
+        return array(
+            array(array('parameter' => 'foobar'), null),
+            array(array('foobar' => 'barfoo'), 'InvalidArgumentException'), // This is deliberately generic to preserve BC from SF 2.5 > 2.6
+            array(array(), 'Symfony\Component\OptionsResolver\Exception\MissingOptionsException'),
+        );
+    }
+
+    /**
+     * @dataProvider provideParameterValue
+     */
+    public function testParameterValue($options, $expectedException)
+    {
+        if (null !== $expectedException) {
+            $this->setExpectedException($expectedException);
+        }
+
+        $this->container->getParameter('foobar')->willReturn('barfoo');
+
+        $optionsResolver = new OptionsResolver();
+        $this->provider->configureOptions($optionsResolver);
+        $options = $optionsResolver->resolve($options);
+
+        $res = $this->provider->provideValue($this->uriContext->reveal(), $options);
+
+        $this->assertEquals('barfoo', $res);
+    }
+}
+

--- a/TokenProvider/SymfonyContainerParameterProvider.php
+++ b/TokenProvider/SymfonyContainerParameterProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\RoutingAuto\TokenProvider;
+
+use Symfony\Cmf\Component\RoutingAuto\TokenProviderInterface;
+use Symfony\Cmf\Component\RoutingAuto\UriContext;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provide values parameters from a Symfony DI container
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class SymfonyContainerParameterProvider implements TokenProviderInterface
+{
+    protected $container;
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValue(UriContext $uriContext, $options)
+    {
+        $parameterName = $options['parameter'];
+
+        return $this->container->getParameter($parameterName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolverInterface $optionsResolver)
+    {
+        $optionsResolver->setRequired(array(
+            'parameter'
+        ));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.1",
+        "symfony/dependency-injection": "~2.0",
         "phpspec/prophecy": "~1.1.2"
     },
     "suggest": {


### PR DESCRIPTION
Token provider which provides values from Symfony DI container.parameters.

Should we also support providing values from services?

````yaml
stdClass:
    uri_schema: {base_path}/sub/path
    token_providers:
        base_path: [ container, [ parameter: "my.bundle.some.parameter" ]
````