### PR TITLE
Added expression provider

### DIFF
--- a/Tests/Unit/TokenProvider/ExpressionProviderTest.php
+++ b/Tests/Unit/TokenProvider/ExpressionProviderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Component\RoutingAuto\Tests\Unit\TokenProvider;
+
+use Symfony\Cmf\Component\RoutingAuto\Tests\Unit\BaseTestCase;
+use Symfony\Cmf\Component\RoutingAuto\TokenProvider\ContentMethodProvider;
+use Symfony\Component\DependencyInjection\ExpressionLanguage;
+use Symfony\Cmf\Component\RoutingAuto\TokenProvider\ExpressionProvider;
+
+class ExpressionProviderTest extends BaseTestCase
+{
+    protected $slugifier;
+    protected $article;
+    protected $uriContext;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->article = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Tests\Resources\Fixtures\Article');
+        $this->uriContext = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\UriContext');
+        $this->provider = new ExpressionProvider(new ExpressionLanguage());
+    }
+
+    public function provideGetValue()
+    {
+        return array(
+            array(
+                'hello',
+                'subject.getTitle()',
+                'hello',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideGetValue
+     */
+    public function testGetValue($title, $expression, $expected)
+    {
+        $this->uriContext->getSubjectObject()->willReturn($this->article);
+        $this->article->getTitle()->willReturn($title);
+
+        $options = array(
+            'expression' => $expression
+        );
+
+        $res = $this->provider->provideValue($this->uriContext->reveal(), $options);
+        $this->assertEquals($expected, $res);
+    }
+}

--- a/TokenProvider/ExpressionProvider.php
+++ b/TokenProvider/ExpressionProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Component\RoutingAuto\TokenProvider;
+
+use Symfony\Cmf\Component\RoutingAuto\TokenProviderInterface;
+use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Cmf\Component\RoutingAuto\UriContext;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+class ExpressionProvider implements TokenProviderInterface
+{
+    protected $slugifier;
+    protected $language;
+
+    public function __construct(ExpressionLanguage $language)
+    {
+        $this->language = $language;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValue(UriContext $uriContext, $options)
+    {
+        $subject = $uriContext->getSubjectObject();
+        $expression = $options['expression'];
+        $evaluation = $this->language->evaluate($expression, array(
+            'subject' => $subject
+        ));
+
+        return $evaluation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolverInterface $optionsResolver)
+    {
+        $optionsResolver->setRequired(array(
+            'expression',
+        ));
+
+        $optionsResolver->setAllowedTypes(array(
+            'expression' => 'string',
+        ));
+    }
+}


### PR DESCRIPTION
This PR add a Symfony Expression Language provier.

This provides a very dynamic way to genereate URLs, for example:

```
stdClass:
    uri_schema: /{path}
    token_providers:
        path: [expression, { expression: 'parameter.cmf_routing.basepath + "/" + slugify(subject.title) }]
```

The expression language is not modified within the provider and it is up to the developer to provide a suitably featureful language to the provider. For example one which provides access to container parameters, a slugifier and the locale.

We could provide either a fully featured ExpressionLanguage in this component, or provide one which is composable somehow.
