### PR TITLE
[REJECTED] Support for Host schema, route options and http schemes

### DIFF
--- a/AdapterInterface.php
+++ b/AdapterInterface.php
@@ -49,7 +49,7 @@ interface AdapterInterface
      *
      * @return AutoRouteInterface new route document
      */
-    public function createAutoRoute($path, $document, $tag);
+    public function createAutoRoute(UriContext $uriContext, $tag);
 
     /**
      * Return the canonical name for the given class, this is

--- a/AutoRouteManager.php
+++ b/AutoRouteManager.php
@@ -71,7 +71,10 @@ class AutoRouteManager
 
             if (!$autoRoute) {
                 $autoRouteTag = $this->adapter->generateAutoRouteTag($uriContext);
-                $autoRoute = $this->adapter->createAutoRoute($uriContext->getUri(), $uriContext->getSubjectObject(), $autoRouteTag);
+                $autoRoute = $this->adapter->createAutoRoute(
+                    $uriContext,
+                    $autoRouteTag
+                );
             }
 
             $uriContext->setAutoRoute($autoRoute);
@@ -106,10 +109,7 @@ class AutoRouteManager
             $uriContextCollection->addUriContext($uriContext);
 
             // generate the URL
-            $uri = $this->uriGenerator->generateUri($uriContext);
-
-            // update the context with the URL
-            $uriContext->setUri($uri);
+            $this->uriGenerator->generateUri($uriContext);
         }
     }
 }

--- a/Mapping/ClassMetadata.php
+++ b/Mapping/ClassMetadata.php
@@ -28,6 +28,21 @@ class ClassMetadata extends MergeableClassMetadata
     protected $uriSchema;
 
     /**
+     * @var string
+     */
+    protected $hostSchema;
+
+    /**
+     * @var array
+     */
+    protected $routeOptions = array();
+
+    /**
+     * @var array
+     */
+    protected $allowedSchemes = array();
+
+    /**
      * @var array
      */
     protected $tokenProviders = array();
@@ -69,6 +84,67 @@ class ClassMetadata extends MergeableClassMetadata
     public function getUriSchema()
     {
         return $this->uriSchema;
+    }
+
+    /**
+     * Return the host schema
+     *
+     * @return string
+     */
+    public function getHostSchema() 
+    {
+        return $this->hostSchema;
+    }
+
+    /**
+     * Set the host schema
+     *
+     * @param string $hostSchema
+     */
+    public function setHostSchema($hostSchema)
+    {
+        $this->hostSchema = $hostSchema;
+    }
+
+    /**
+     * Return the route options
+     *
+     * @return array
+     */
+    public function getRouteOptions() 
+    {
+        return $this->routeOptions;
+    }
+
+    /**
+     * Set the route options
+     *
+     * @param array $routeOptions
+     */
+    public function setRouteOptions($routeOptions)
+    {
+        $this->routeOptions = $routeOptions;
+    }
+
+    /**
+     * Set allowed allowedSchemes
+     * e.g. array('http') or array('http', 'https'), etc.
+     *
+     * @return array
+     */
+    public function getAllowedSchemes() 
+    {
+        return $this->allowedSchemes;
+    }
+
+    /**
+     * Add an allowed scheme
+     *
+     * @param string $scheme
+     */
+    public function addAllowedScheme($scheme)
+    {
+        $this->allowedSchemes[] = $scheme;
     }
 
     /**

--- a/Mapping/Loader/YmlFileLoader.php
+++ b/Mapping/Loader/YmlFileLoader.php
@@ -81,6 +81,9 @@ class YmlFileLoader extends FileLoader
 
         $validKeys = array(
             'uri_schema',
+            'host_scheme',
+            'route_options',
+            'allowed_schemes',
             'conflict_resolver',
             'defunct_route_handler',
             'extend',
@@ -98,6 +101,17 @@ class YmlFileLoader extends FileLoader
             switch ($key) {
                 case 'uri_schema':
                     $classMetadata->setUriSchema($value);
+                    break;
+                case 'host_scheme':
+                    $classMetadata->setHostSchema($value);
+                    break;
+                case 'route_options':
+                    $classMetadata->setRouteOptions($mappingNode['route_options']);
+                    break;
+                case 'allowed_schemes':
+                    foreach ($mappingNode['allowed_schemes'] as $scheme) {
+                        $classMetadata->addAllowedScheme($scheme);
+                    }
                     break;
                 case 'conflict_resolver':
                     $classMetadata->setConflictResolver($this->parseServiceConfig($mappingNode['conflict_resolver'], $className, $path));

--- a/Mapping/Loader/schema/auto-routing/auto-routing-1.0.xsd
+++ b/Mapping/Loader/schema/auto-routing/auto-routing-1.0.xsd
@@ -17,11 +17,22 @@
             <xsd:element name="conflict-resolver" type="conflict-resolver" minOccurs="0" />
             <xsd:element name="defunct-route-handler" type="defunct-route-handler" minOccurs="0" />
             <xsd:element name="token-provider" type="token-provider" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="route-option" type="route-option" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="scheme" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
 
         <xsd:attribute name="class" type="xsd:string" />
         <xsd:attribute name="uri-schema" type="xsd:string" />
+        <xsd:attribute name="host-schema" type="xsd:string" />
         <xsd:attribute name="extend" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="route-option">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:string" />
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
 
     <xsd:complexType name="token-provider">

--- a/Tests/Resources/Fixtures/loader_config/valid7.xml
+++ b/Tests/Resources/Fixtures/loader_config/valid7.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<auto-mapping xmlns="http://cmf.symfony.com/schema/routing_auto">
+    <mapping class="stdClass" uri-schema="/blog/{category}/{slug}" host-schema="foobar.dom">
+        <route-option name="bar">foo</route-option>
+        <route-option name="foo">bar</route-option>
+        <scheme>http</scheme>
+        <scheme>https</scheme>
+    </mapping>
+</auto-mapping>

--- a/Tests/Resources/Fixtures/loader_config/valid7.yml
+++ b/Tests/Resources/Fixtures/loader_config/valid7.yml
@@ -1,0 +1,8 @@
+stdClass:
+    uri_schema: /blog/{category}/{slug}
+    host_scheme: foobar.dom
+    route_options:
+        foo: bar
+        bar: foo
+    allowed_schemes: [ http, https ]
+

--- a/Tests/Unit/Mapping/ClassMetadataTest.php
+++ b/Tests/Unit/Mapping/ClassMetadataTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Component\RoutingAuto\Tests\Unit\Mapping;
+
+use Symfony\Cmf\Component\RoutingAuto\Mapping\ClassMetadata;
+use Symfony\Cmf\Component\RoutingAuto\Tests\Unit\BaseTestCase;
+
+class ClassMetadataTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->classMetadata = new ClassMetadata('\stdClass');
+    }
+
+    public function provideGetSet()
+    {
+        return array(
+            array(
+                'uriSchema', '/path/to',
+            ),
+            array(
+                'hostSchema', 'foo.bar',
+            ),
+            array(
+                'routeOptions', array('foo' => 'bar'),
+            ),
+            array(
+                'allowedSchemes', array('http', 'https'),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideGetSet
+     */
+    public function testGetSet($field, $value)
+    {
+        $getter = 'get' . ucfirst($field);
+        $setter = 'set' . ucfirst($field);
+
+        $this->classMetadata->$setter($value);
+        $res = $this->classMetadata->$getter();
+
+        $this->assertEquals($value, $res);
+    }
+}
+

--- a/Tests/Unit/Mapping/Loader/XmlFileLoaderTest.php
+++ b/Tests/Unit/Mapping/Loader/XmlFileLoaderTest.php
@@ -158,6 +158,18 @@ class XmlFileLoaderTest extends BaseTestCase
                 $test->assertArrayHasKey('slug', $providers);
                 $test->assertEquals($serviceConfig('property', array('property' => 'title', 'slugify' => true)), $providers['slug']);
             }),
+
+            // host schema, route options and allowedSchemes
+            array('valid7.xml', function ($metadatas) use ($test) {
+                $test->assertCount(1, $metadatas);
+                $metadata = $metadatas[0];
+
+                $test->assertEquals('stdClass', $metadata->getClassName());
+                $test->assertEquals('/blog/{category}/{slug}', $metadata->getUriSchema());
+                $test->assertEquals('foobar.dom', $metadata->getHostSchema());
+                $test->assertEquals(array('http', 'https'), $metadata->getAllowedSchemes());
+                $this->assertEquals(array('bar' => 'foo', 'foo' => 'bar'), $metadata->getRouteOptions());
+            }),
         );
     }
 

--- a/Tests/Unit/Mapping/Loader/YmlFileLoaderTest.php
+++ b/Tests/Unit/Mapping/Loader/YmlFileLoaderTest.php
@@ -169,6 +169,15 @@ class YmlFileLoaderTest extends BaseTestCase
                 $test->assertArrayHasKey('category', $providers);
                 $test->assertEquals('foo', $providers['category']['name']);
             }),
+            array('valid7.yml', function ($metadatas) use ($test, $serviceConfig) {
+                $test->assertCount(1, $metadatas);
+                $metadata = $metadatas[0];
+                $test->assertEquals('stdClass', $metadata->getClassName());
+                $test->assertEquals('/blog/{category}/{slug}', $metadata->getUriSchema());
+                $test->assertEquals('foobar.dom', $metadata->getHostSchema());
+                $test->assertEquals(array('http', 'https'), $metadata->getAllowedSchemes());
+                $this->assertEquals(array('bar' => 'foo', 'foo' => 'bar'), $metadata->getRouteOptions());
+            }),
         );
     }
 

--- a/Tests/Unit/UriContextTest.php
+++ b/Tests/Unit/UriContextTest.php
@@ -44,6 +44,11 @@ class UriContextTest extends BaseTestCase
         // auto route
         $uriContext->setAutoRoute($this->autoRoute);
         $this->assertEquals($this->autoRoute, $uriContext->getAutoRoute());
+
+        // host
+        $this->assertEquals(null, $uriContext->getHost());
+        $uriContext->setHost('host');
+        $this->assertEquals('host', $uriContext->getHost());
     }
 }
 

--- a/UriContext.php
+++ b/UriContext.php
@@ -23,6 +23,7 @@ class UriContext
     protected $locale;
     protected $uri;
     protected $autoRoute;
+    protected $host;
 
     public function __construct($subjectObject, $locale)
     {
@@ -38,6 +39,16 @@ class UriContext
     public function setUri($uri)
     {
         $this->uri = $uri;
+    }
+
+    public function setHost($host)
+    {
+        $this->host = $host;
+    }
+
+    public function getHost()
+    {
+        return $this->host;
     }
 
     public function getSubjectObject()

--- a/UriGenerator.php
+++ b/UriGenerator.php
@@ -66,7 +66,26 @@ class UriGenerator implements UriGeneratorInterface
         }
 
         $uriSchema = $metadata->getUriSchema();
+        $hostSchema = $metadata->getHostSchema();
+        $allowedSchemes = $metadata->getAllowedSchemes();
+        $routeOptions = $metadata->getRouteOptions();
+
         $uri = strtr($uriSchema, $tokens);
+
+        if ($hostSchema) {
+            $host = strtr($hostSchema, $tokens);
+        }
+
+        $uriContext->setUri($uri);
+        $uriContext->setHost($host);
+
+        if ($allowedSchemes) {
+            $uriContext->setAllowedSchemes($allowedSchemes);
+        }
+
+        if ($routeOptions) {
+            $uriContext->setRouteOptions($routeOptions);
+        }
 
         return $uri;
     }

--- a/UriGeneratorInterface.php
+++ b/UriGeneratorInterface.php
@@ -23,8 +23,6 @@ interface UriGeneratorInterface
      * Generate a URL for the given document
      *
      * @param object $document
-     *
-     * @return string
      */
     public function generateUri(UriContext $uriContext);
 


### PR DESCRIPTION
tl;dr; I don't think this is  a good idea, and we should implement an event dispatcher instead.

This PR is In reponse to the PR https://github.com/symfony-cmf/RoutingAuto/pull/21 which adds support for mapping arbitrary values to route methods, which aims to solve the issue https://github.com/symfony-cmf/RoutingAutoBundle/pull/139

This PR adds support for adding a host, schemes [ http, https ], and route *options* to the routing auto configuration:

````yaml
foobar:
   uri_schema: bar/foo
   host_schema: sub.{domain}.com
   token_providers:
       domain: [ content_method, {method: 'getDomain'} ]
   allowed_schemes: [ https ]
   route_options:
       custom_option: one
       custom_option: two
````

All of the above options can be mapped directly to Symfonys Route object.

There are problems however with the **host_schema**:

- We will need to refactor conflict resolution
- We need to change the adapter interface
- Token provides now have a dual role in providing tokens for URLs and Hosts - 
  which are two different things.

And, for all that **I do not think it good practice to store the host name
in the route**, neither in PHPCR or in an ORM. This is breaking the DRY rule.

The host name would be better placed (in PHPCR) as part of the path, and in
an ORM as an ID refering to some Host table.

Saying that, storing the host or anyother attribute in the Route document could
be easily facilitated if we implement an EventDispatcher.

So basically, I suggest that we forget about this for now and instead implement an **Event Dispatcher** and a ``cmf_routing_auto.post_auto_route`` event or some-such.

p.s. If we implement the Event Dispatcher then the conflcit resolver would still need to be aware of the `host` property of routes, which I think would be a harmless addition.