### PR TITLE
Added event dispatcher and URI_CONTEXT_BUILT event

### DIFF
--- a/AutoRouteManager.php
+++ b/AutoRouteManager.php
@@ -14,6 +14,9 @@ namespace Symfony\Cmf\Component\RoutingAuto;
 
 use Symfony\Cmf\Component\RoutingAuto\AdapterInterface;
 use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
+use Symfony\Cmf\Component\RoutingAuto\RoutingAutoEvents;
+use Symfony\Cmf\Component\RoutingAuto\Event\UriContextEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * This class is concerned with the automatic creation of route objects.
@@ -22,30 +25,54 @@ use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
  */
 class AutoRouteManager
 {
+    /**
+     * @var AdapterInterface
+     */
     protected $adapter;
+
+    /**
+     * @var UriGeneratorInterface
+     */
     protected $uriGenerator;
+
+    /**
+     * @var DefunctRouteHandlerInterface
+     */
     protected $defunctRouteHandler;
 
+    /**
+     * @var EventDispatcher
+     */
+    protected $eventDispatcher;
+
+    /**
+     * @var UriContextCollection[]
+     */
     private $pendingUriContextCollections = array();
 
     /**
      * @param AdapterInterface             $adapter             Database adapter
      * @param UriGeneratorInterface        $uriGenerator        Routing auto URL generator
      * @param DefunctRouteHandlerInterface $defunctRouteHandler Handler for defunct routes
+     * @param EventDispatcher              $eventDispatcher     Dispatcher for events
      */
     public function __construct(
         AdapterInterface $adapter,
         UriGeneratorInterface $uriGenerator,
-        DefunctRouteHandlerInterface $defunctRouteHandler
+        DefunctRouteHandlerInterface $defunctRouteHandler,
+        EventDispatcher $eventDispatcher
     )
     {
         $this->adapter = $adapter;
         $this->uriGenerator = $uriGenerator;
         $this->defunctRouteHandler = $defunctRouteHandler;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
-     * @param object $document
+     * Build the URI context classes into the given UriContextCollection
+     *
+     * @param UriContextCollection $uriContextCollection
      */
     public function buildUriContextCollection(UriContextCollection $uriContextCollection)
     {
@@ -57,16 +84,7 @@ class AutoRouteManager
             $autoRoute = null;
 
             if ($existingRoute) {
-                $isSameContent = $this->adapter->compareAutoRouteContent($existingRoute, $uriContext->getSubjectObject());
-
-                if ($isSameContent) {
-                    $autoRoute = $existingRoute;
-                    $autoRoute->setType(AutoRouteInterface::TYPE_PRIMARY);
-                } else {
-                    $uri = $uriContext->getUri();
-                    $uri = $this->uriGenerator->resolveConflict($uriContext);
-                    $uriContext->setUri($uri);
-                }
+                $this->handleExistingRoute($existingRoute, $uriContext);
             }
 
             if (!$autoRoute) {
@@ -75,15 +93,45 @@ class AutoRouteManager
             }
 
             $uriContext->setAutoRoute($autoRoute);
+
+            if ($this->eventDispatcher) {
+                $event = new UriContextEvent($uriContext);
+                $this->eventDispatcher->dispatch(RoutingAutoEvents::URI_CONTEXT_BUILT, $event);
+            }
         }
 
         $this->pendingUriContextCollections[] = $uriContextCollection;
     }
 
+    /**
+     * Process defunct (no longer used) routes
+     */
     public function handleDefunctRoutes()
     {
         while ($uriContextCollection = array_pop($this->pendingUriContextCollections)) {
             $this->defunctRouteHandler->handleDefunctRoutes($uriContextCollection);
+        }
+    }
+
+    /**
+     * Handle the case where the generated path already exists.
+     * Either if it does not reference the same content then we 
+     * have a conflict which needs to be resolved.
+     *
+     * @param Route $route
+     * @param UriContext $uriContext
+     */
+    private function handleExistingRoute($existingRoute, $uriContext)
+    {
+        $isSameContent = $this->adapter->compareAutoRouteContent($existingRoute, $uriContext->getSubjectObject());
+
+        if ($isSameContent) {
+            $autoRoute = $existingRoute;
+            $autoRoute->setType(AutoRouteInterface::TYPE_PRIMARY);
+        } else {
+            $uri = $uriContext->getUri();
+            $uri = $this->uriGenerator->resolveConflict($uriContext);
+            $uriContext->setUri($uri);
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 Changelog
 =========
 
+dev-master
+----------
+
+* **2014-12-07**: Added event dispatcher and URI_CONTEXT_BUILT event
+
 1.0
 ---
 
 * **2014-08-19**: Added validation for yaml routing auto configuration keys
 * **2014-08-10**: Replaced all instances of the term URL with URI
 * Separated this package from the RoutingAutoBundle
+

--- a/Event/UriContextEvent.php
+++ b/Event/UriContextEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Cmf\Component\RoutingAuto\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Cmf\Component\RoutingAuto\UriContext;
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class UriContextEvent extends Event
+{
+    private $uriContext;
+
+    public function __construct(UriContext $uriContext)
+    {
+        $this->uriContext = $uriContext;
+    }
+
+    public function getUriContext()
+    {
+        return $this->uriContext;
+    }
+}

--- a/RoutingAutoEvents.php
+++ b/RoutingAutoEvents.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\RoutingAuto;
+
+class RoutingAutoEvents
+{
+    /**
+     * Dispatched when the UriContext has been built
+     */
+    const URI_CONTEXT_BUILT = 'cmf_routing_auto.uri_context_built';
+}

--- a/Tests/Unit/AutoRouteManagerTest.php
+++ b/Tests/Unit/AutoRouteManagerTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Cmf\Component\RoutingAuto\Tests\Unit;
 
 use Symfony\Cmf\Component\RoutingAuto\AutoRouteManager;
 use Symfony\Cmf\Component\RoutingAuto\UriContextCollection;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Cmf\Component\RoutingAuto\Event\UriContextEvent;
+use Symfony\Cmf\Component\RoutingAuto\RoutingAutoEvents;
 
 class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,10 +25,13 @@ class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
         $this->driver = $this->getMock('Symfony\Cmf\Component\RoutingAuto\AdapterInterface');
         $this->uriGenerator = $this->getMock('Symfony\Cmf\Component\RoutingAuto\UriGeneratorInterface');
         $this->defunctRouteHandler = $this->getMock('Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandlerInterface');
+        $this->eventDispatcher = new EventDispatcher();
+        $this->eventDispatcher->addListener(RoutingAutoEvents::URI_CONTEXT_BUILT, array($this, 'onUriContextBuilt'));
         $this->autoRouteManager = new AutoRouteManager(
             $this->driver,
             $this->uriGenerator,
-            $this->defunctRouteHandler
+            $this->defunctRouteHandler,
+            $this->eventDispatcher
         );
     }
 
@@ -90,5 +96,14 @@ class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
         foreach ($expectedRoutes as $expectedRoute) {
             $this->assertTrue($uriContextCollection->containsAutoRoute($expectedRoute), 'URL context collection contains route: ' . spl_object_hash($expectedRoute));
         }
+    }
+
+    /**
+     * For testing the event listener
+     */
+    public function onUriContextBuilt(UriContextEvent $event)
+    {
+        $uriContext = $event->getUriContext();
+        $this->assertInstanceOf('Symfony\Cmf\Component\RoutingAuto\UriContext', $uriContext);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "symfony-cmf/routing": "~1.2",
         "symfony/options-resolver": "~2.2",
         "symfony/config": "~2.2",
+        "symfony/event-dispatcher": "~2.2",
         "jms/metadata": "1.5.*"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds an EventDispatcher to the AutoRouteManager and dispatches an event after each URI context is built.

This event enables the user to modify the "auto route" after it has been updated / created. Notably it would enable setting fields such as `host` on the Route document.

The `UriContext` object has access to the generated URI, the subject object (for which the route is being generated) and the route itself.

````php
class SomeEventHandler
{
    public function handleUriContextBuilt(UriContextEvent $event)
    {
        $uriContext = $event->getUriContext();

        $autoRoute = $uriContext->getAutoRoute();
        $uri = $uriContext->getUri();
        $content = $uriContext->getSubjectObject();

        if (null === $autoRoute->getId()) {
            // its a new auto route
        } else {
            // its an old one
        }

        $autoRoute->setHost('mydomain.dom');
    }
}
