### PR TITLE
POC for defunct route options

### DIFF
--- a/ConfigurableInterface.php
+++ b/ConfigurableInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Component\RoutingAuto;
+
+/**
+ * This interface should be implemented by classes which
+ * need to configure options.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+interface ConfigurableInterface
+{
+    /**
+     * Configure the options for this token provider
+     *
+     * @param OptionsResolverInterface $optionsResolver
+     */
+    public function configureOptions(OptionsResolverInterface $optionsResolver);
+}

--- a/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
+++ b/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
@@ -9,20 +9,22 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandler;
 
 use Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandlerInterface;
 use Symfony\Cmf\Component\RoutingAuto\UriContextCollection;
 use Symfony\Cmf\Component\RoutingAuto\AdapterInterface;
 
-class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
+class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface, ConfigurableInterface
 {
     /**
      * @var AdapterInterface
      */
     protected $adapter;
 
+    /**
+     * @param AdapterInterface $adapter
+     */
     public function __construct(AdapterInterface $adapter)
     {
         $this->adapter = $adapter;
@@ -31,7 +33,15 @@ class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public function handleDefunctRoutes(UriContextCollection $uriContextCollection)
+    public function configureOptions(OptionsResolverInterface $optionsResolver)
+    {
+        $optionsResolver->setDefault('http_code', 301);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handleDefunctRoutes(UriContextCollection $uriContextCollection, array $options = array())
     {
         $referringAutoRouteCollection = $this->adapter->getReferringAutoRoutes($uriContextCollection->getSubjectObject());
 

--- a/DefunctRouteHandler/RemoveDefunctRouteHandler.php
+++ b/DefunctRouteHandler/RemoveDefunctRouteHandler.php
@@ -34,7 +34,7 @@ class RemoveDefunctRouteHandler implements DefunctRouteHandlerInterface
     /**
      * {@inheritDoc}
      */
-    public function handleDefunctRoutes(UriContextCollection $uriContextCollection)
+    public function handleDefunctRoutes(UriContextCollection $uriContextCollection, array $options = array())
     {
         $referringAutoRouteCollection = $this->adapter->getReferringAutoRoutes($uriContextCollection->getSubjectObject());
 

--- a/DefunctRouteHandlerInterface.php
+++ b/DefunctRouteHandlerInterface.php
@@ -12,6 +12,8 @@
 
 namespace Symfony\Cmf\Component\RoutingAuto;
 
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
 /**
  * @author Daniel Leech <daniel@dantleech.com>
  */
@@ -28,7 +30,8 @@ interface DefunctRouteHandlerInterface
      * or perhaps replaced with a redirect route, or indeed
      * left alone to continue depending on the configuration.
      *
-     * TODO
+     * @param UriContextCollection $uriContextCollection
+     * @param array $options
      */
-    public function handleDefunctRoutes(UriContextCollection $uriContextCollection);
+    public function handleDefunctRoutes(UriContextCollection $uriContextCollection, array $options = array());
 }

--- a/TokenProviderInterface.php
+++ b/TokenProviderInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Cmf\Component\RoutingAuto;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-interface TokenProviderInterface
+interface TokenProviderInterface extends ConfigurableInterface
 {
     /**
      * Return a token value for the given configuration and
@@ -26,11 +26,4 @@ interface TokenProviderInterface
      * @return string
      */
     public function provideValue(UriContext $uriContext, $options);
-
-    /**
-     * Configure the options for this token provider
-     *
-     * @param OptionsResolverInterface $optionsResolver
-     */
-    public function configureOptions(OptionsResolverInterface $optionsResolver);
 }


### PR DESCRIPTION
The aim of this POC PR is to explore the possiblity passing options to the defunct route handlers - the use case being allowing the redirect HTTP code to be passed to the adapter which creates the redirect route.

Intitially I tried to avoid BC breaks, but the requirement to add `$options` to the `handleDefunctRoutes` method breaks any chance of this. The role of the new `ConfigurableInterface` is therefore up for debate.