### PR TITLE
Collapse empty tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 dev-master
 ----------
 
+* **2015-04-19**: [BC Break] Empty token values will now throw an exception
+* **2015-04-19**: Added `allow_empty` option to permit empty values and
+                  remove any trailing slash.
 * **2015-03-14**: [BC Break] The adapter now accepts the `UriContext` object for
                   `createRoute` and as an additional parameter to `findRouteForUri`.
 * **2015-03-14**: Changed adapter interface to accept UriContext objects

--- a/Tests/Unit/UriGeneratorTest.php
+++ b/Tests/Unit/UriGeneratorTest.php
@@ -41,6 +41,7 @@ class UriGeneratorTest extends \PHPUnit_Framework_TestCase
     public function provideGenerateUri()
     {
         return array(
+            // tokens should be substituted with values from the token providers
             array(
                 '/this/is/{token_the_first}/a/uri',
                 '/this/is/foobar_value/a/uri',
@@ -52,6 +53,7 @@ class UriGeneratorTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
+            // tokens should be substituted with values from the token providers
             array(
                 '/{this}/{is}/{token_the_first}/a/uri',
                 '/that/was/foobar_value/a/uri',
@@ -73,22 +75,128 @@ class UriGeneratorTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
             ),
+            // an exception should be thrown if the token provider is not known
             array(
                 '/this/is/{unknown_token}/life',
                 null,
                 array(),
                 array('InvalidArgumentException', 'Unknown token "unknown_token"'),
             ),
+            // an exception should be thrown if the generated URI is not absolute
             array(
                 'this/is/not/absolute',
                 null,
                 array(),
                 array('InvalidArgumentException', 'Generated non-absolute URI'),
             ),
+            // no tokens need to be specified
             array(
                 '/this/is/has/no/tokens',
                 '/this/is/has/no/tokens',
                 array(),
+            ),
+            // nothing should happen if allow_empty is true and the value is not empty
+            array(
+                '/{parent}/title',
+                '/foobar_value/title',
+                array(
+                    'parent' => array(
+                        'name' => 'foobar_provider',
+                        'value' => 'foobar_value',
+                        'options' => array(
+                            'allow_empty' => true,
+                        ),
+                    ),
+                ),
+            ),
+            // the empty token should be collapsed when allow_empty is true
+            array(
+                '/{parent}/title',
+                '/title',
+                array(
+                    'parent' => array(
+                        'name' => 'foobar_provider',
+                        'value' => '',
+                        'options' => array(
+                            'allow_empty' => true,
+                        ),
+                    ),
+                ),
+            ),
+            // if the token value is a single "/" then it should be treated as an empty value and
+            // any trailing slash should be collapsed.
+            array(
+                '{parent}/title',
+                '/title',
+                array(
+                    'parent' => array(
+                        'name' => 'foobar_provider',
+                        'value' => '/',
+                        'options' => array(
+                            'allow_empty' => true,
+                        ),
+                    ),
+                ),
+            ),
+            // if the last segment is empty and allow empty is true, then remove the leading slash
+            array(
+                '/{locale}/{parent}',
+                '/de',
+                array(
+                    'locale' => array(
+                        'name' => 'foobar_provider',
+                        'value' => 'de',
+                        'options' => array(
+                            'allow_empty' => true,
+                        ),
+                    ),
+                    'parent' => array(
+                        'name' => 'barbar_provider',
+                        'value' => '',
+                        'options' => array(
+                            'allow_empty' => true,
+                        ),
+                    ),
+                ),
+            ),
+            // if the last segment is empty and has a trailing slash then the trailing slash should be
+            // preserved
+            array(
+                '/{locale}/{parent}/',
+                '/de/',
+                array(
+                    'locale' => array(
+                        'name' => 'foobar_provider',
+                        'value' => 'de',
+                        'options' => array(
+                            'allow_empty' => true,
+                        ),
+                    ),
+                    'parent' => array(
+                        'name' => 'barbar_provider',
+                        'value' => '',
+                        'options' => array(
+                            'allow_empty' => true,
+                        ),
+                    ),
+                ),
+            ),
+            // an exception should be thrown if a token is empty and allow_empty is false
+            array(
+                '/{parent}/title',
+                '/title',
+                array(
+                    'parent' => array(
+                        'name' => 'foobar_provider',
+                        'value' => '',
+                        'options' => array(
+                            'allow_empty' => false,
+                        ),
+                    ),
+                ),
+                array(
+                    'InvalidArgumentException', 'Token provider "foobar_provider" returned an empty value',
+                ),
             ),
         );
     }
@@ -119,6 +227,11 @@ class UriGeneratorTest extends \PHPUnit_Framework_TestCase
             ->willReturn($uriSchema);
 
         foreach ($tokenProviderConfigs as $tokenName => $tokenProviderConfig) {
+            // set the defaults for the predictions
+            $tokenProviderConfig['options'] = array_merge(array(
+                'allow_empty' => false,
+            ), $tokenProviderConfig['options']);
+
             $providerName = $tokenProviderConfig['name'];
 
             $this->tokenProviders[$providerName] = $this->prophesize(


### PR DESCRIPTION
This PR:

- Throws an exception by default when a token provider produces an empty value
- Adds a global token provider option `collapse_empty` which permits empty tokens and removes any trailing slash.

Fixes: https://github.com/symfony-cmf/RoutingAuto/issues/35