### PR TITLE
Handle case where referencing URI is not in context collection

### DIFF
--- a/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
+++ b/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
@@ -36,8 +36,11 @@ class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
         $referringAutoRouteCollection = $this->adapter->getReferringAutoRoutes($uriContextCollection->getSubjectObject());
 
         foreach ($referringAutoRouteCollection as $referringAutoRoute) {
-            if (false === $uriContextCollection->containsAutoRoute($referringAutoRoute)) {
-                $newRoute = $uriContextCollection->getAutoRouteByTag($referringAutoRoute->getAutoRouteTag());
+            if (true === $uriContextCollection->containsAutoRoute($referringAutoRoute)) {
+                continue;
+            }
+
+            $newRoute = $uriContextCollection->getAutoRouteByTag($referringAutoRoute->getAutoRouteTag());
 
                 if (null === $newRoute) {
                     continue;
@@ -45,8 +48,8 @@ class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
 
                 $this->adapter->migrateAutoRouteChildren($referringAutoRoute, $newRoute);
                 $this->adapter->createRedirectRoute($referringAutoRoute, $newRoute);
-            }
+
+            $this->adapter->createRedirectRoute($referringAutoRoute, $newRoute);
         }
     }
 }
-

--- a/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
+++ b/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
@@ -42,13 +42,12 @@ class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
 
             $newRoute = $uriContextCollection->getAutoRouteByTag($referringAutoRoute->getAutoRouteTag());
 
-                if (null === $newRoute) {
-                    continue;
-                }
+            if (!$newRoute) {
+                // it could happen that the referring route is for a non-existing locale
+                continue;
+            }
 
-                $this->adapter->migrateAutoRouteChildren($referringAutoRoute, $newRoute);
-                $this->adapter->createRedirectRoute($referringAutoRoute, $newRoute);
-
+            $this->adapter->migrateAutoRouteChildren($referringAutoRoute, $newRoute);
             $this->adapter->createRedirectRoute($referringAutoRoute, $newRoute);
         }
     }

--- a/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
+++ b/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
@@ -13,6 +13,7 @@
 namespace Symfony\Cmf\Component\RoutingAuto\Tests\Unit\DefunctRouteHandler;
 
 use Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandler\LeaveRedirectDefunctRouteHandler;
+use Prophecy\Argument;
 
 class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -43,7 +44,6 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         ));
         $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(true);
         $this->uriContextCollection->containsAutoRoute($this->route2->reveal())->willReturn(false);
-        $this->uriContextCollection->containsAutoRoute($this->route3->reveal())->willReturn(true);
 
         $this->route2->getAutoRouteTag()->willReturn('fr');
         $this->uriContextCollection->getAutoRouteByTag('fr')->willReturn($this->route4);
@@ -70,5 +70,21 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         $this->adapter->migrateAutoRouteChildren($this->route2->reveal(), $this->route4->reveal())->shouldNotBeCalled();
         $this->handler->handleDefunctRoutes($this->uriContextCollection->reveal());
     }
-}
 
+    public function testNonExistingReferrerLocale()
+    {
+        $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
+        $this->adapter->getReferringAutoRoutes($this->subjectObject)->willReturn(array(
+            $this->route1, $this->route2
+        ));
+        $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(true);
+        $this->uriContextCollection->containsAutoRoute($this->route2->reveal())->willReturn(false);
+
+        $this->route2->getAutoRouteTag()->willReturn('fr');
+        $this->uriContextCollection->getAutoRouteByTag('fr')->willReturn(null);
+
+        $this->adapter->createRedirectRoute(Argument::any())->shouldNotBeCalled();
+
+        $this->handler->handleDefunctRoutes($this->uriContextCollection->reveal());
+    }
+}

--- a/UriContextCollection.php
+++ b/UriContextCollection.php
@@ -120,4 +120,20 @@ class UriContextCollection
 
         return null;
     }
+
+    /**
+     * Return a list of all the autoroute tags contained in this collection
+     *
+     * @return array
+     */
+    public function getAutoRouteTags()
+    {
+        $tags = array();
+        foreach ($this->uriContexts as $uriContext) {
+            $autoRoute = $uriContext->getAutoRoute();
+            $tags[] = $autoRoute->getAutoRouteTag();
+        }
+
+        return $tags;
+    }
 }


### PR DESCRIPTION
If the referring defunct (old) route is not in the current URI context collection then it means that the locale of the referring node is no longer existing.

This should be handled otherwise `null` will be passed to the Adapter.