### PR TITLE
POC implementation of multiple routes

### DIFF
--- a/AutoRouteManager.php
+++ b/AutoRouteManager.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Component\RoutingAuto;
 
 use Symfony\Cmf\Component\RoutingAuto\AdapterInterface;
 use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
+use Symfony\Cmf\Component\RoutingAuto\UriContextBuilder;
 
 /**
  * This class is concerned with the automatic creation of route objects.
@@ -23,24 +24,24 @@ use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
 class AutoRouteManager
 {
     protected $adapter;
-    protected $uriGenerator;
+    protected $uriContextBuilder;
     protected $defunctRouteHandler;
 
     private $pendingUriContextCollections = array();
 
     /**
      * @param AdapterInterface             $adapter             Database adapter
-     * @param UriGeneratorInterface        $uriGenerator        Routing auto URL generator
+     * @param UriGeneratorInterface        $uriContextBuilder        Routing auto URL generator
      * @param DefunctRouteHandlerInterface $defunctRouteHandler Handler for defunct routes
      */
     public function __construct(
         AdapterInterface $adapter,
-        UriGeneratorInterface $uriGenerator,
+        UriContextBuilder $uriContextBuilder,
         DefunctRouteHandlerInterface $defunctRouteHandler
     )
     {
         $this->adapter = $adapter;
-        $this->uriGenerator = $uriGenerator;
+        $this->uriContextBuilder = $uriContextBuilder;
         $this->defunctRouteHandler = $defunctRouteHandler;
     }
 
@@ -49,7 +50,7 @@ class AutoRouteManager
      */
     public function buildUriContextCollection(UriContextCollection $uriContextCollection)
     {
-        $this->getUriContextsForDocument($uriContextCollection);
+        $this->buildUriContextsForDocument($uriContextCollection);
 
         foreach ($uriContextCollection->getUriContexts() as $uriContext) {
             $existingRoute = $this->adapter->findRouteForUri($uriContext->getUri(), $uriContext);
@@ -57,21 +58,20 @@ class AutoRouteManager
             $autoRoute = null;
 
             if ($existingRoute) {
-                $isSameContent = $this->adapter->compareAutoRouteContent($existingRoute, $uriContext->getSubjectObject());
+                $isSameContent = $this->adapter->compareAutoRouteContent($existingRoute, $uriContextCollection->getSubjectObject());
 
                 if ($isSameContent) {
                     $autoRoute = $existingRoute;
                     $autoRoute->setType(AutoRouteInterface::TYPE_PRIMARY);
                 } else {
-                    $uri = $uriContext->getUri();
-                    $uri = $this->uriGenerator->resolveConflict($uriContext);
+                    $uri = $this->resolveConflict($uriContext->getUri());
                     $uriContext->setUri($uri);
                 }
             }
 
             if (!$autoRoute) {
                 $autoRouteTag = $this->adapter->generateAutoRouteTag($uriContext);
-                $autoRoute = $this->adapter->createAutoRoute($uriContext, $uriContext->getSubjectObject(), $autoRouteTag);
+                $autoRoute = $this->adapter->createAutoRoute($uriContext, $uriContextCollection->getSubjectObject(), $autoRouteTag);
             }
 
             $uriContext->setAutoRoute($autoRoute);
@@ -92,7 +92,7 @@ class AutoRouteManager
      *
      * @param $uriContextCollection UriContextCollection
      */
-    private function getUriContextsForDocument(UriContextCollection $uriContextCollection)
+    private function buildUriContextsForDocument(UriContextCollection $uriContextCollection)
     {
         $locales = $this->adapter->getLocales($uriContextCollection->getSubjectObject()) ? : array(null);
 
@@ -101,7 +101,24 @@ class AutoRouteManager
                 $this->adapter->translateObject($uriContextCollection->getSubjectObject(), $locale);
             }
 
-            $this->uriContextBuilder->buildCollection($uriContextCollection, $locale);
+            $this->uriContextBuilder->build($uriContextCollection, $locale);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolveConflict(UriContext $uriContext)
+    {
+        $metadata = $uriContext->getRouteMetadata();
+        $config = $metadata->getConflictResolver();
+        $conflictResolver = $this->serviceRegistry->getConflictResolver(
+            $config['name'], 
+            $config['options']
+        );
+        $uri = $conflictResolver->resolveConflict($uriContext);
+
+        return $uri;
+    }
+
 }

--- a/AutoRouteManager.php
+++ b/AutoRouteManager.php
@@ -101,15 +101,7 @@ class AutoRouteManager
                 $this->adapter->translateObject($uriContextCollection->getSubjectObject(), $locale);
             }
 
-            // create and add uri context to stack
-            $uriContext = $uriContextCollection->createUriContext($locale);
-            $uriContextCollection->addUriContext($uriContext);
-
-            // generate the URL
-            $uri = $this->uriGenerator->generateUri($uriContext);
-
-            // update the context with the URL
-            $uriContext->setUri($uri);
+            $this->uriContextBuilder->buildCollection($uriContextCollection, $locale);
         }
     }
 }

--- a/Mapping/RouteMetadata.php
+++ b/Mapping/RouteMetadata.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Component\RoutingAuto\Mapping;
+
+use Metadata\MergeableInterface;
+use Metadata\MergeableClassMetadata;
+
+/**
+ * Holds the metadata for one class.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RouteMetadata extends MergeableClassMetadata
+{
+    /**
+     * @var string
+     */
+    protected $uriSchema;
+
+    /**
+     * @var array
+     */
+    protected $tokenProviders = array();
+
+    /** 
+     * @var array
+     */
+    protected $conflictResolver = array('name' => 'throw_exception', 'options' => array());
+
+    /**
+     * Defunct route handler, default to remove
+     *
+     * @var array
+     */
+    protected $defunctRouteHandler = array('name' => 'remove');
+
+    /**
+     * Set the URL schema to use for the subject class.
+     *
+     * e.g. {foobar}/articles/{date}
+     *
+     * @param string $schema
+     */
+    public function setUriSchema($schema)
+    {
+        $this->uriSchema = $schema;
+    }
+
+    /**
+     * Return the URL schema
+     *
+     * @return string
+     */
+    public function getUriSchema()
+    {
+        return $this->uriSchema;
+    }
+
+    /**
+     * Add a token provider configfuration.
+     *
+     * @param string $tokenName
+     * @param array $provider
+     * @param boolean $override
+     */
+    public function addTokenProvider($tokenName, array $provider = array(), $override = false)
+    {
+        if ('schema' === $tokenName) {
+            throw new \InvalidArgumentException(sprintf('Class "%s" has an invalid token name "%s": schema is a reserved token name.', $this->name, $tokenName));
+        }
+
+        if (!$override && isset($this->tokenProvider[$tokenName])) {
+            throw new \InvalidArgumentException(sprintf('Class "%s" already has a token provider for token "%s", set the third argument of addTokenProvider to true to override it.', $this->name, $tokenName));
+        }
+
+        $this->tokenProviders[$tokenName] = $provider;
+    }
+
+    /**
+     * Return an associative array of token provider configurations.
+     * Keys are the token provider names, values are configurations in
+     * array format.
+     *
+     * @return array
+     */
+    public function getTokenProviders()
+    {
+        return $this->tokenProviders;
+    }
+
+    /**
+     * Set the conflict resolver configuration.
+     *
+     * @param array
+     */
+    public function setConflictResolver($conflictResolver)
+    {
+        $this->conflictResolver = $conflictResolver;
+    }
+
+    /**
+     * Return the conflict resolver configuration.
+     *
+     * @return array
+     */
+    public function getConflictResolver()
+    {
+        return $this->conflictResolver;
+    }
+
+    /**
+     * Set the defunct route handler configuration.
+     *
+     * e.g.
+     *
+     *   array('remove', array('option1' => 'value1'))
+     *
+     * @param array
+     */
+    public function setDefunctRouteHandler($defunctRouteHandler)
+    {
+        $this->defunctRouteHandler = $defunctRouteHandler;
+    }
+
+    /**
+     * Return the defunct route handler configuration
+     */
+    public function getDefunctRouteHandler()
+    {
+        return $this->defunctRouteHandler;
+    }
+
+
+    /**
+     * Merges another AutoRouteMetadata into the current metadata.
+     *
+     * Caution: the registered token providers will be overriden when the new
+     * ClassMetadata has a token provider with the same name.
+     *
+     * The URL schema will be overriden, you can use {parent} to refer to the
+     * previous URL schema.
+     *
+     * @param ClassMetadata $metadata
+     */
+    public function merge(MergeableInterface $metadata)
+    {
+        $this->uriSchema = str_replace('{parent}', $this->uriSchema, $metadata->getUriSchema());
+
+        foreach ($metadata->getTokenProviders() as $tokenName => $provider) {
+            $this->addTokenProvider($tokenName, $provider, true);
+        }
+
+        if ($defunctRouteHandler = $metadata->getDefunctRouteHandler()) {
+            $this->setDefunctRouteHandler($defunctRouteHandler);
+        }
+
+        if ($conflictResolver = $metadata->getConflictResolver()) {
+            $this->setConflictResolver($conflictResolver);
+        }
+    }
+}

--- a/Tests/Resources/Fixtures/loader_config/valid7.yml
+++ b/Tests/Resources/Fixtures/loader_config/valid7.yml
@@ -1,0 +1,11 @@
+stdClass:
+    extends: foobar
+    routes:
+        one:
+            uri_schema: /forum/{category}/{post_title}
+            token_providers:
+                category: [foo]
+        two:
+            uri_schema: /admin/standard/{id}
+            token_providers:
+                id: [foo]

--- a/Tests/Unit/AutoRouteManagerTest.php
+++ b/Tests/Unit/AutoRouteManagerTest.php
@@ -14,81 +14,124 @@ namespace Symfony\Cmf\Component\RoutingAuto\Tests\Unit;
 
 use Symfony\Cmf\Component\RoutingAuto\AutoRouteManager;
 use Symfony\Cmf\Component\RoutingAuto\UriContextCollection;
+use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
 
 class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->driver = $this->getMock('Symfony\Cmf\Component\RoutingAuto\AdapterInterface');
-        $this->uriGenerator = $this->getMock('Symfony\Cmf\Component\RoutingAuto\UriGeneratorInterface');
-        $this->defunctRouteHandler = $this->getMock('Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandlerInterface');
-        $this->autoRouteManager = new AutoRouteManager(
-            $this->driver,
-            $this->uriGenerator,
-            $this->defunctRouteHandler
+        $this->adapter = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\AdapterInterface');
+        $this->uriContextBuilder = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\UriContextBuilder');
+        $this->defunctRouteHandler = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandlerInterface');
+        $this->manager = new AutoRouteManager(
+            $this->adapter->reveal(),
+            $this->uriContextBuilder->reveal(),
+            $this->defunctRouteHandler->reveal()
         );
-    }
 
-    public function provideBuildUriContextCollection()
-    {
-        return array(
-            array(
-                array(
-                    'locales' => array('en', 'fr', 'de', 'be'),
-                    'uris' => array(
-                        '/en/this-is-an-route' => array('conflict' => false),
-                        '/fr/this-is-an-route' => array('conflict' => false),
-                        '/de/this-is-an-route' => array('conflict' => false),
-                        '/be/this-is-an-route' => array('conflict' => false),
-                    ),
-                    'existingRoute' => false,
-                ),
-            ),
-        );
+        $this->route1Meta = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Mapping\RouteMetadata');
+        $this->route1 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
+        $this->route2 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
+        $this->uriContext1 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\UriContext');
+        $this->uriContext1->getUri()->willReturn('/u/r/i/1');
+        $this->uriContext2 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\UriContext');
+        $this->uriContext2->getUri()->willReturn('/u/r/i/2');
     }
 
     /**
-     * @dataProvider provideBuildUriContextCollection
+     * It should build a localized URI Context Collection
+     * It should create new routes
      */
-    public function testBuildUriContextCollection($params)
+    public function testCreateNewRoutes()
     {
-        $params = array_merge(array(
-            'locales' => array(),
-            'uris' => array(),
-        ), $params);
-
-        $this->driver->expects($this->once())
-            ->method('getLocales')
-            ->will($this->returnValue($params['locales']));
-
-        $localesCount = count($params['locales']);
-        $uris = $params['uris'];
-        $indexedUris = array_keys($uris);
-        $expectedRoutes = array();
         $document = new \stdClass;
+        $collection = new UriContextCollection($document);
+        $uriContexts = array($this->uriContext1, $this->uriContext2);
+        $this->adapter->getLocales($document)->willReturn(array('fr', 'de'));
+        $this->adapter->translateObject($document, 'fr')->shouldBeCalled();
+        $this->adapter->translateObject($document, 'de')->shouldBeCalled();
 
-        for ($i = 0; $i < $localesCount; $i++) {
-            $expectedRoutes[] = $this->getMock('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
+        $this->uriContextBuilder->build($collection, 'fr')->will(function ($args) use ($uriContexts) {
+            $args[0]->addUriContext($uriContexts[0]->reveal());
+        });
+        $this->uriContextBuilder->build($collection, 'de')->will(function ($args) use ($uriContexts) {
+            $args[0]->addUriContext($uriContexts[1]->reveal());
+        });
 
-            $this->uriGenerator->expects($this->exactly($localesCount))
-                ->method('generateUri')
-                ->will($this->returnCallback(function () use ($i, $indexedUris) {
-                    return $indexedUris[$i];
-                }));
-        }
+        $this->adapter->findRouteForUri('/u/r/i/1', $this->uriContext1)->willReturn(null);
+        $this->adapter->findRouteForUri('/u/r/i/2', $this->uriContext2)->willReturn(null);
+        $this->adapter->generateAutoRouteTag($this->uriContext1)->willReturn('tag1');
+        $this->adapter->generateAutoRouteTag($this->uriContext2)->willReturn('tag2');
+        $this->adapter->createAutoRoute($this->uriContext1, $document, 'tag1')->willReturn($this->route1->reveal());
+        $this->adapter->createAutoRoute($this->uriContext2, $document, 'tag2')->willReturn($this->route2->reveal());
+        $this->uriContext1->setAutoRoute($this->route1)->shouldBeCalled();
+        $this->uriContext2->setAutoRoute($this->route2)->shouldBeCalled();
+        $this->manager->buildUriContextCollection($collection);
+    }
 
-        $this->driver->expects($this->exactly($localesCount))
-            ->method('createAutoRoute')
-            ->will($this->returnCallback(function ($uri, $document) use ($expectedRoutes) {
-                static $i = 0;
-                return $expectedRoutes[$i++];
-            }));
+    /**
+     * It should build a non-localized URI Context Collection
+     */
+    public function testNonLocalized()
+    {
+        $document = new \stdClass;
+        $collection = new UriContextCollection($document);
+        $uriContext = $this->uriContext1;
+        $this->adapter->getLocales($document)->willReturn(null);
 
-        $uriContextCollection = new UriContextCollection($document);
-        $this->autoRouteManager->buildUriContextCollection($uriContextCollection);
+        $this->uriContextBuilder->build($collection, null)->will(function ($args) use ($uriContext) {
+            $args[0]->addUriContext($uriContext->reveal());
+        });
 
-        foreach ($expectedRoutes as $expectedRoute) {
-            $this->assertTrue($uriContextCollection->containsAutoRoute($expectedRoute), 'URL context collection contains route: ' . spl_object_hash($expectedRoute));
-        }
+        $this->adapter->findRouteForUri('/u/r/i/1', $this->uriContext1)->willReturn(null);
+        $this->adapter->generateAutoRouteTag($this->uriContext1)->willReturn('tag1');
+        $this->adapter->createAutoRoute($this->uriContext1, $document, 'tag1')->willReturn($this->route1->reveal());
+        $this->uriContext1->setAutoRoute($this->route1)->shouldBeCalled();
+        $this->manager->buildUriContextCollection($collection);
+    }
+
+    /**
+     * It should use an existing route for the same content
+     * It should set an existing route type to PRIMARY
+     */
+    public function testExistingSameContent()
+    {
+        $document = new \stdClass;
+        $collection = new UriContextCollection($document);
+        $uriContext = $this->uriContext1;
+        $this->adapter->getLocales($document)->willReturn(null);
+
+        $this->uriContextBuilder->build($collection, null)->will(function ($args) use ($uriContext) {
+            $args[0]->addUriContext($uriContext->reveal());
+        });
+
+        $this->adapter->findRouteForUri('/u/r/i/1', $this->uriContext1)->willReturn($this->route1->reveal());
+        $this->adapter->compareAutoRouteContent($this->route1->reveal(), $document)->willReturn(true);
+        $this->route1->setType(AutoRouteInterface::TYPE_PRIMARY)->shouldBeCalled();
+
+        $this->uriContext1->setAutoRoute($this->route1)->shouldBeCalled();
+        $this->manager->buildUriContextCollection($collection);
+    }
+
+    /**
+     * It should resolve conflicts with existing routes that are not related to the same content.
+     */
+    public function testExistingNotSameContent()
+    {
+        $document = new \stdClass;
+        $collection = new UriContextCollection($document);
+        $uriContext = $this->uriContext1;
+        $this->adapter->getLocales($document)->willReturn(null);
+
+        $this->uriContextBuilder->build($collection, null)->will(function ($args) use ($uriContext) {
+            $args[0]->addUriContext($uriContext->reveal());
+        });
+
+        $this->adapter->findRouteForUri('/u/r/i/1', $this->uriContext1)->willReturn($this->route1->reveal());
+        $this->adapter->compareAutoRouteContent($this->route1->reveal(), $document)->willReturn(false);
+        $this->uriContext1->getRouteMetadata()->willReturn($this->route1Meta->reveal());
+
+        $this->uriContext1->setAutoRoute($this->route1)->shouldBeCalled();
+        $this->manager->buildUriContextCollection($collection);
     }
 }

--- a/UriContext.php
+++ b/UriContext.php
@@ -27,10 +27,11 @@ class UriContext
     protected $autoRoute;
     protected $routeMetadata;
 
-    public function __construct($subjectObject, $locale)
+    public function __construct($subjectObject, $routeMetadata, $locale)
     {
         $this->subjectObject = $subjectObject;
         $this->locale = $locale;
+        $this->routeMetadata = $routeMetadata;
     }
 
     public function getUri()
@@ -48,12 +49,6 @@ class UriContext
         return $this->routeMetadata;
     }
     
-    public function setRouteMetadata(RouteMetadata $routeMetadata)
-    {
-        $this->routeMetadata = $routeMetadata;
-    }
-    
-
     public function getSubjectObject()
     {
         return $this->subjectObject;

--- a/UriContext.php
+++ b/UriContext.php
@@ -12,6 +12,8 @@
 
 namespace Symfony\Cmf\Component\RoutingAuto;
 
+use Symfony\Cmf\Component\RoutingAuto\Mapping\RouteMetadata;
+
 /**
  * Class which represents a URL and its associated locale
  *
@@ -23,6 +25,7 @@ class UriContext
     protected $locale;
     protected $uri;
     protected $autoRoute;
+    protected $routeMetadata;
 
     public function __construct($subjectObject, $locale)
     {
@@ -39,6 +42,17 @@ class UriContext
     {
         $this->uri = $uri;
     }
+
+    public function getRouteMetadata() 
+    {
+        return $this->routeMetadata;
+    }
+    
+    public function setRouteMetadata(RouteMetadata $routeMetadata)
+    {
+        $this->routeMetadata = $routeMetadata;
+    }
+    
 
     public function getSubjectObject()
     {

--- a/UriContextBuilder.php
+++ b/UriContextBuilder.php
@@ -15,14 +15,17 @@ namespace Symfony\Cmf\Component\RoutingAuto;
 use Symfony\Cmf\Component\RoutingAuto\Mapping\MetadataFactory;
 
 /**
- *
- * @author Daniel Leech <daniel@dantleech.com>
+ * Builds up the URI Context Collections.
  */
 class UriContextBuilder
 {
     private $metadataFactory;
     private $uriGenerator;
 
+    /**
+     * @param MetadataFactoryInterface $metadataFactory
+     * @param UriGeneratorInterface $uriGenerator
+     */
     public function __construct(
         MetadataFactoryInterface $metadataFactory,
         UriGeneratorInterface $uriGenerator
@@ -32,7 +35,14 @@ class UriContextBuilder
         $this->uriGenerator = $uriGenerator;
     }
 
-    public function buildCollection(UriContextCollection $collection, $locale)
+    /**
+     * Populates the given UriContextCollection (with associated subject)
+     * with processed UriContexts.
+     *
+     * @param UriContextCollection $collection
+     * @param string $locale
+     */
+    public function build(UriContextCollection $collection, $locale)
     {
         $subject = $collection->getSubjectObject();
         $realClassName = $this->driver->getRealClassName(get_class($subject));
@@ -40,8 +50,7 @@ class UriContextBuilder
 
         foreach ($metadata->getRouteMetadatas() as $routeMetadata) {
             // create and add uri context to stack
-            $uriContext = $uriContextCollection->createUriContext($locale);
-            $uriContext->setRouteMetadata($routeMetadata);
+            $uriContext = $uriContextCollection->createUriContext($locale, $routeMetadata);
             $uriContextCollection->addUriContext($uriContext);
 
             // generate the URL

--- a/UriContextBuilder.php
+++ b/UriContextBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Component\RoutingAuto;
+
+use Symfony\Cmf\Component\RoutingAuto\Mapping\MetadataFactory;
+
+/**
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class UriContextBuilder
+{
+    private $metadataFactory;
+    private $uriGenerator;
+
+    public function __construct(
+        MetadataFactoryInterface $metadataFactory,
+        UriGeneratorInterface $uriGenerator
+    )
+    {
+        $this->metadataFactory = $metadataFactory;
+        $this->uriGenerator = $uriGenerator;
+    }
+
+    public function buildCollection(UriContextCollection $collection, $locale)
+    {
+        $subject = $collection->getSubjectObject();
+        $realClassName = $this->driver->getRealClassName(get_class($subject));
+        $metadata = $this->metadataFactory->getMetadataForClass($realClassName);
+
+        foreach ($metadata->getRouteMetadatas() as $routeMetadata) {
+            // create and add uri context to stack
+            $uriContext = $uriContextCollection->createUriContext($locale);
+            $uriContext->setRouteMetadata($routeMetadata);
+            $uriContextCollection->addUriContext($uriContext);
+
+            // generate the URL
+            $uri = $this->uriGenerator->generateUri($uriContext);
+
+            // update the context with the URL
+            $uriContext->setUri($uri);
+        }
+    }
+}

--- a/UriContextCollection.php
+++ b/UriContextCollection.php
@@ -13,6 +13,7 @@
 namespace Symfony\Cmf\Component\RoutingAuto;
 
 use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
+use Symfony\Cmf\Component\RoutingAuto\Mapping\RouteMetadata;
 
 class UriContextCollection
 {
@@ -46,11 +47,12 @@ class UriContextCollection
      *
      * @return UriContext
      */
-    public function createUriContext($locale)
+    public function createUriContext($locale, RouteMetadata $routeMetadata)
     {
         $uriContext = new UriContext(
             $this->getSubjectObject(),
-            $locale
+            $locale,
+            $routeMetadata
         );
 
         return $uriContext;

--- a/UriGenerator.php
+++ b/UriGenerator.php
@@ -24,7 +24,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class UriGenerator implements UriGeneratorInterface
 {
     protected $driver;
-    protected $metadataFactory;
     protected $serviceRegistry;
 
     /**
@@ -33,12 +32,10 @@ class UriGenerator implements UriGeneratorInterface
      * @param ServiceRegistry  the auto route service registry
      */
     public function __construct(
-        MetadataFactoryInterface $metadataFactory,
         AdapterInterface $driver,
         ServiceRegistry $serviceRegistry
     )
     {
-        $this->metadataFactory = $metadataFactory;
         $this->driver = $driver;
         $this->serviceRegistry = $serviceRegistry;
     }
@@ -48,8 +45,7 @@ class UriGenerator implements UriGeneratorInterface
      */
     public function generateUri(UriContext $uriContext)
     {
-        $realClassName = $this->driver->getRealClassName(get_class($uriContext->getSubjectObject()));
-        $metadata = $this->metadataFactory->getMetadataForClass($realClassName);
+        $metadata = $uriContext->getRouteMetadata();
         $uriSchema = $metadata->getUriSchema();
 
         $tokenProviderConfigs = $metadata->getTokenProviders();

--- a/UriGenerator.php
+++ b/UriGenerator.php
@@ -113,7 +113,6 @@ class UriGenerator implements UriGeneratorInterface
     public function resolveConflict(UriContext $uriContext)
     {
         $realClassName = $this->driver->getRealClassName(get_class($uriContext->getSubjectObject()));
-        $metadata = $this->metadataFactory->getMetadataForClass($realClassName);
 
         $conflictResolverConfig = $metadata->getConflictResolver();
         $conflictResolver = $this->serviceRegistry->getConflictResolver(


### PR DESCRIPTION
This PR is primiminary attempt at supporting the generation of multiple routes (from schemas) for a single class.

The configuration would look as follows:

````
stdClass:
    extend: foo
    routes:
        route_one:
            uri_schema: /route/to/{foo]
            token_providers:
                foo: [ bar ]
        route_two:
            uri_schema: /path/to/{foo]
            token_providers:
                foo: [ bar ]
````

While also supporting the current format:
    
````
stdClass:
    extend: foo
    uri_schema: /route/to/{foo]
    token_providers:
        foo: [ bar ]
````
