### PR TITLE
Adapter#translateObject() has to return the translated object

### DIFF
--- a/AdapterInterface.php
+++ b/AdapterInterface.php
@@ -23,9 +23,11 @@ use Symfony\Cmf\Component\RoutingAuto\UriContext;
 interface AdapterInterface
 {
     /**
-     * Return locales for object
+     * Get the locales for object.
      *
-     * @return array
+     * @param object $object
+     *
+     * @return array A list of locales
      */
     public function getLocales($object);
 
@@ -33,7 +35,9 @@ interface AdapterInterface
      * Translate the given object into the given locale
      *
      * @param object $object
-     * @param string $locale e.g. fr, en, de, be, etc.
+     * @param string $locale E.g. fr, en, etc.
+     *
+     * @return object The translated subject object
      */
     public function translateObject($object, $locale);
 
@@ -41,9 +45,9 @@ interface AdapterInterface
      * Create a new auto route at the given path
      * with the given document as the content.
      *
-     * @param string $path
-     * @param object $document
-     * @param string $tag
+     * @param UriContext $uriContext
+     * @param object     $document
+     * @param string     $tag
      *
      * @return AutoRouteInterface new route document
      */
@@ -53,28 +57,32 @@ interface AdapterInterface
      * Return the canonical name for the given class, this is
      * required as somethimes an ORM may return a proxy class.
      *
+     * @param string $className
+     *
      * @return string
      */
     public function getRealClassName($className);
 
     /**
-     * Return true if the content associated with the auto route
-     * and the given content object are the same.
+     * Compares the content associated with the auto route and the
+     * given content object.
      *
-     * @param RouteObjectInterface
-     * @param object
+     * @param AutoRouteInterface $autoRoute
+     * @param object             $contentObject
+     *
+     * @return bool True when the contents are equal, false otherwise
      */
     public function compareAutoRouteContent(AutoRouteInterface $autoRoute, $contentObject);
 
     /**
      * Attempt to find a route with the given URL
      *
-     * Note that the URI may not be the same as the URI in the URI context, 
+     * Note that the URI may not be the same as the URI in the URI context,
      * this will happen when the ConflictResolver is trying to find candidate
      * URLs for example.
      *
-     * @param string $uri The URI to find
-     * @param UriContext $uri The current URI context
+     * @param string     $uri        The URI to find
+     * @param UriContext $uriContext The current URI context
      *
      * @return null|Symfony\Cmf\Component\Routing\RouteObjectInterface
      */
@@ -85,6 +93,8 @@ interface AdapterInterface
      * other routes as required.
      *
      * @param UriContext $uriContext
+     *
+     * @return string
      */
     public function generateAutoRouteTag(UriContext $uriContext);
 
@@ -135,7 +145,7 @@ interface AdapterInterface
      * The referring auto route should either be deleted or scheduled to be removed,
      * so the route created here will replace it.
      *
-     * The new redirecvt route should redirect the request to the URL determined by
+     * The new redirect route should redirect the request to the URL determined by
      * the $newRoute.
      *
      * @param AutoRouteInterface $referringAutoRoute

--- a/AutoRouteManager.php
+++ b/AutoRouteManager.php
@@ -138,7 +138,13 @@ class AutoRouteManager
 
         foreach ($locales as $locale) {
             if (null !== $locale) {
-                $this->adapter->translateObject($uriContextCollection->getSubjectObject(), $locale);
+                $subjectObject = $this->adapter->translateObject($uriContextCollection->getSubjectObject(), $locale);
+
+                if (null !== $subjectObject) {
+                    $uriContextCollection->setSubjectObject($subjectObject);
+                } else {
+                    @trigger_error('AdapterInterface::translateObject() has to return the subjectObject as of version 1.1, support for by reference will be removed in 2.0.', E_USER_DEPRECATED);
+                }
             }
 
             // create and add uri context to stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 dev-master
 ----------
 
+* **2015-08-23**: `AdapterInterface::translateObject()` now has to return the
+                  translated object, by reference is still supported for BC reasons.
 * **2015-04-23**: Added EventDispatching adapter
 * **2015-04-19**: [BC Break] Empty token values will now throw an exception
 * **2015-04-19**: Added `allow_empty` option to permit empty values and

--- a/UriContextCollection.php
+++ b/UriContextCollection.php
@@ -16,13 +16,26 @@ use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
 
 class UriContextCollection
 {
+    /**
+     * @var object
+     */
     protected $subjectObject;
     protected $uriContexts = array();
 
     /**
-     * @param mixed $subjectObject Subject for URL generation
+     * @param object $subjectObject Subject for URL generation
      */
     public function __construct($subjectObject)
+    {
+        $this->subjectObject = $subjectObject;
+    }
+
+    /**
+     * Set the subject for URL generation.
+     *
+     * @param object $subjectObject
+     */
+    public function setSubjectObject($subjectObject)
     {
         $this->subjectObject = $subjectObject;
     }
@@ -39,9 +52,8 @@ class UriContextCollection
     }
 
     /**
-     * Create and a URL context
+     * Create a URL context.
      *
-     * @param string $uri    URL
      * @param string $locale Locale for given URL
      *
      * @return UriContext
@@ -57,7 +69,7 @@ class UriContextCollection
     }
 
     /**
-     * Push a URL context onto the stack
+     * Push a URL context onto the stack.
      *
      * @param UriContext $uriContext
      */
@@ -72,10 +84,12 @@ class UriContextCollection
     }
 
     /**
-     * Return true if any one of the UriContexts in the stacj
-     * contain the given auto route
+     * Check if any of the UriContexts in the stack contain
+     * the given auto route.
      *
      * @param AutoRouteInterface $autoRoute
+     *
+     * @return bool
      */
     public function containsAutoRoute(AutoRouteInterface $autoRoute)
     {
@@ -88,6 +102,13 @@ class UriContextCollection
         return false;
     }
 
+    /**
+     * Get an auto route by its tag (e.g. the locale).
+     *
+     * @param mixed $tag
+     *
+     * @return AutoRouteInterface|null
+     */
     public function getAutoRouteByTag($tag)
     {
         foreach ($this->uriContexts as $uriContext) {


### PR DESCRIPTION
The PhpcrOdmAdapter is already doing this and it is more flexible (not all adapters might be able to things like this by reference).

Kept BC, but triggered a silenced deprecation notices. As this error is not visible, unless you use a custom error handler (like the one showing the deprecation notices in the toolbar), this is a very friendly way to indicate the user might have to change its code. Tests do no longer fail because of this (and adding trigger_error directly is also going to be the standard in Symfony core as of 3.0).