### PR TITLE
Migrate children on redirect

### DIFF
--- a/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
+++ b/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
@@ -39,6 +39,11 @@ class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
             if (false === $uriContextCollection->containsAutoRoute($referringAutoRoute)) {
                 $newRoute = $uriContextCollection->getAutoRouteByTag($referringAutoRoute->getAutoRouteTag());
 
+                if (null === $newRoute) {
+                    continue;
+                }
+
+                $this->adapter->migrateAutoRouteChildren($referringAutoRoute, $newRoute);
                 $this->adapter->createRedirectRoute($referringAutoRoute, $newRoute);
             }
         }

--- a/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
+++ b/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
@@ -35,7 +35,7 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testHandleDefunctRoutes()
+    public function testLeaveRedirect()
     {
         $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
         $this->adapter->getReferringAutoRoutes($this->subjectObject)->willReturn(array(
@@ -50,6 +50,24 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->adapter->createRedirectRoute($this->route2->reveal(), $this->route4->reveal())->shouldBeCalled();
 
+        $this->adapter->migrateAutoRouteChildren($this->route2->reveal(), $this->route4->reveal())->shouldBeCalled();
+        $this->handler->handleDefunctRoutes($this->uriContextCollection->reveal());
+    }
+
+    public function testLeaveDirectNoTranslation()
+    {
+        $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
+        $this->adapter->getReferringAutoRoutes($this->subjectObject)->willReturn(array(
+            $this->route1
+        ));
+        $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(false);
+
+        $this->route1->getAutoRouteTag()->willReturn('fr');
+        $this->uriContextCollection->getAutoRouteByTag('fr')->willReturn(null);
+
+        $this->adapter->createRedirectRoute($this->route2->reveal(), $this->route4->reveal())->shouldNotBeCalled();
+
+        $this->adapter->migrateAutoRouteChildren($this->route2->reveal(), $this->route4->reveal())->shouldNotBeCalled();
         $this->handler->handleDefunctRoutes($this->uriContextCollection->reveal());
     }
 }


### PR DESCRIPTION
See issue https://github.com/symfony-cmf/RoutingAuto/issues/42

Currently children are not migrated when the redirect defunct route handler is used. This means that routes would passively be migrated over time. This PR aims to migrate all the children when the redirect is created.

I would like to add some functional tests in the RoutingAutoBundle for merging this.