### PR TITLE
Removed type hint to enable redirect target to be a content document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 Changelog
 =========
 
-dev-master
-----------
-
-* **2015-09-15**: Removed type hint from `AutoRouteInterface::setRedirectTarget` to allow
-                  redirect target to be a content document.
+* **2015-09-15**: [BC Break] Removed type hint from `AutoRouteInterface::setRedirectTarget()`
+                  to allow the redirect target to be a content document.
 * **2015-09-05**: "Leave Redirect" defunct route handler now migrates any children
                   of the original route.
 * **2015-08-23**: `AdapterInterface::translateObject()` now has to return the
@@ -15,7 +12,7 @@ dev-master
 * **2015-04-19**: Added `allow_empty` option to permit empty values and
                   remove any trailing slash.
 * **2015-03-14**: [BC Break] The adapter now accepts the `UriContext` object for
-                  `createRoute` and as an additional parameter to `findRouteForUri`.
+                  `createRoute()` and as an additional parameter to `findRouteForUri()`.
 * **2015-03-14**: Changed adapter interface to accept UriContext objects
                   instead of or in addition to URI strings.
 * **2015-01-29**: Added SymfonyContainerParameterTokenProvider for retrieving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 dev-master
 ----------
 
+* **2015-09-15**: Removed type hint from `AutoRouteInterface::setRedirectTarget` to allow
+                  redirect target to be a content document.
 * **2015-09-05**: "Leave Redirect" defunct route handler now migrates any children
                   of the original route.
 * **2015-08-23**: `AdapterInterface::translateObject()` now has to return the

--- a/Model/AutoRouteInterface.php
+++ b/Model/AutoRouteInterface.php
@@ -59,12 +59,12 @@ interface AutoRouteInterface extends RouteObjectInterface
     public function setType($mode);
 
     /**
-     * For use in the REDIRECT mode, specifies the AutoRoute
+     * For use in the REDIRECT mode, specifies the routable object
      * that the AutoRoute should redirect to.
      *
      * @param AutoRouteInterface AutoRoute to redirect to.
      */
-    public function setRedirectTarget(AutoRouteInterface $autoTarget);
+    public function setRedirectTarget($autoTarget);
 
     /**
      * Return the redirect target (when the auto route is of type


### PR DESCRIPTION
Fix for #43 

Currently we only support creating a redirect to another route. This means that if a route is renamed 50 times and somebody visits the initial route, a chain of 50 route documents will need to be resolved.

With this change it will be possible for the adapter to assign the *content* as the redirect target.