### PR TITLE
Add RoutingAutoBundle 1.0 to conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "symfony-cmf/routing-auto-bundle": "To integrate this lirbary with Symfony and the CMF",
         "symfony/event-dispatcher": "To use the EventDispatchingAdapter, allowing to edit the AutoRoute documents (^2.2|3.*)"
     },
+    "conflicts": {
+        "symfony-cmf/routing-auto-bundle": "1.0.*"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Cmf\\Component\\RoutingAuto\\": "" }
     },


### PR DESCRIPTION
These versions of the bundle do not support RoutingAuto 1.1, as there are some BC breaks. However, already released versions of the bundle still seem to suggest they support the component.

It's not the nicest solution, but I think it's the best for the end user.